### PR TITLE
Change export to CommonJS in errors.js

### DIFF
--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -7,7 +7,7 @@ const rollbar = new Rollbar({
   captureUnhandledRejections: true
 });
 
-export function captureError(err /*: Error */, req /*: $FlowFixMe */) {
+captureError(err /*: Error */, req /*: $FlowFixMe */) {
   console.error(err);
   rollbar.error(err, req);
 
@@ -16,3 +16,5 @@ export function captureError(err /*: Error */, req /*: $FlowFixMe */) {
     rollbar.wait(resolve);
   });
 }
+
+module.exports = { captureError };

--- a/src/lib/vault.js
+++ b/src/lib/vault.js
@@ -10,7 +10,7 @@ const {
 } = require("./helpers");
 const { loadVocab, hasBeenUsed, countWordUse } = require("./db");
 
-export class Vault {
+class Vault {
   /*::
     data: Array<string>;
     max: number;
@@ -71,3 +71,5 @@ export class Vault {
     }
   }
 }
+
+module.exports = { Vault };


### PR DESCRIPTION
This fixes the following error:

```
Cannot find module 'rollbar'
```

You should be able to deploy with `@now/node@canary` after this change.

Fixes https://github.com/zeit/now-builders/pull/800

Related to https://github.com/zeit/now-builders/issues/791